### PR TITLE
changes orderedList to list to align with FE Slate implementation

### DIFF
--- a/lib/slate_serializer/html.rb
+++ b/lib/slate_serializer/html.rb
@@ -10,7 +10,7 @@ module SlateSerializer
       'li': 'listItem',
       'p': 'paragraph',
       'div': 'paragraph',
-      'ol': 'orderedList',
+      'ol': 'list',
       'ul': 'unorderedList',
       'table': 'table',
       'tbody': 'tbody',

--- a/spec/lib/slate_serializer/html_spec.rb
+++ b/spec/lib/slate_serializer/html_spec.rb
@@ -78,10 +78,10 @@ RSpec.describe SlateSerializer::Html do
         raw = described_class.deserializer(html)
 
         expect(raw.length).to be 1
-        expect(raw[0][:type]).to eq 'orderedList'
+        expect(raw[0][:type]).to eq 'list'
         expect(raw[0][:children].length).to be 4
         expect(raw[0][:children][1][:children].length).to be 2
-        expect(raw[0][:children][1][:children][1][:type]).to eq 'orderedList'
+        expect(raw[0][:children][1][:children][1][:type]).to eq 'list'
       end
     end
 
@@ -174,7 +174,7 @@ RSpec.describe SlateSerializer::Html do
             ]
           },
           {
-            type: 'orderedList',
+            type: 'list',
             children: [
               {
                 type: 'listItem',


### PR DESCRIPTION
Keeps element names aligned with FE implementation. FE looks for these:
```
export enum BlockFormatType {
  'paragraph' = 'paragraph',
  'blockquote' = 'blockquote',
  'link' = 'link',
  'listItem' = 'listItem',
  'list' = 'list',
  'orderedList' = 'orderedList',
}

export enum MarkFormatType {
  'emphasis' = 'emphasis',
  'strong' = 'strong',
  'header' = 'header',
}
```
